### PR TITLE
Use CHARYBDEFS_PORT env variable as the Thrift port if set

### DIFF
--- a/cookbook/recipes.py
+++ b/cookbook/recipes.py
@@ -1,6 +1,7 @@
 import errno
 
 import sys
+import os
 
 sys.path.append('gen-py')
 from server import server
@@ -27,7 +28,9 @@ def usage():
 
 
 def connect():
-    transport = TSocket.TSocket('127.0.0.1', 9090)
+    envPort = os.getenv('CHARIBEFS_PORT', '')
+    port = int(envPort) if envPort else 9090
+    transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)
     protocol = TBinaryProtocol.TBinaryProtocol(transport)
     client = server.Client(protocol)

--- a/cookbook/recipes.py
+++ b/cookbook/recipes.py
@@ -28,7 +28,7 @@ def usage():
 
 
 def connect():
-    envPort = os.getenv('CHARIBEFS_PORT', '')
+    envPort = os.getenv('CHARYBDEFS_PORT', '')
     port = int(envPort) if envPort else 9090
     transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)

--- a/python_client.py
+++ b/python_client.py
@@ -11,7 +11,9 @@ from thrift.protocol import TBinaryProtocol
 
 try:
 
-    transport = TSocket.TSocket('127.0.0.1', 9090)
+    envPort = os.getenv('CHARIBEFS_PORT', '')
+    port = int(envPort) if envPort else 9090
+    transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)
     protocol = TBinaryProtocol.TBinaryProtocol(transport)
     client = server.Client(protocol)

--- a/python_client.py
+++ b/python_client.py
@@ -11,7 +11,7 @@ from thrift.protocol import TBinaryProtocol
 
 try:
 
-    envPort = os.getenv('CHARIBEFS_PORT', '')
+    envPort = os.getenv('CHARYBDEFS_PORT', '')
     port = int(envPort) if envPort else 9090
     transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)

--- a/server.cc
+++ b/server.cc
@@ -252,7 +252,7 @@ void server_thread()
 {
     int port = 9090;
 
-	if(const char* envPort = std::getenv("CHARIBEFS_PORT")) {
+	if(const char* envPort = std::getenv("CHARYBDEFS_PORT")) {
 		char *end;
 		const long envPortValue = strtol(envPort, &end, 10);
 		if (envPort == end) {

--- a/server.cc
+++ b/server.cc
@@ -252,16 +252,16 @@ void server_thread()
 {
     int port = 9090;
 
-	if(const char* envPort = std::getenv("CHARYBDEFS_PORT")) {
-		char *end;
-		const long envPortValue = strtol(envPort, &end, 10);
-		if (envPort == end) {
-			port = static_cast<int>(envPortValue);
-		} else {
-			std::cerr << "Invalid port : " << envPort <<
-			". Using the default value : " << port << std::endl;
-		}
-	}
+    if(const char* envPort = std::getenv("CHARYBDEFS_PORT")) {
+        char *end;
+        const long envPortValue = strtol(envPort, &end, 10);
+        if (envPort == end) {
+            port = static_cast<int>(envPortValue);
+        } else {
+            std::cerr << "Invalid port : " << envPort <<
+            ". Using the default value : " << port << std::endl;
+        }
+    }
 
     init_valid_methods();
 

--- a/server.cc
+++ b/server.cc
@@ -252,6 +252,17 @@ void server_thread()
 {
     int port = 9090;
 
+	if(const char* envPort = std::getenv("CHARIBEFS_PORT")) {
+		char *end;
+		const long envPortValue = strtol(envPort, &end, 10);
+		if (envPort == end) {
+			port = static_cast<int>(envPortValue);
+		} else {
+			std::cerr << "Invalid port : " << envPort <<
+			". Using the default value : " << port << std::endl;
+		}
+	}
+
     init_valid_methods();
 
     std::cout << "Server Thread started" << std::endl;

--- a/server.cc
+++ b/server.cc
@@ -252,10 +252,11 @@ void server_thread()
 {
     int port = 9090;
 
-    if(const char* envPort = std::getenv("CHARYBDEFS_PORT")) {
+    if(const char *envPort = std::getenv("CHARYBDEFS_PORT")) {
         char *end;
+        errno = 0;
         const long envPortValue = strtol(envPort, &end, 10);
-        if (envPort == end) {
+        if (envPort != end && errno == 0) {
             port = static_cast<int>(envPortValue);
         } else {
             std::cerr << "Invalid port : " << envPort <<

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,7 +57,7 @@ def has_message(method, message):
 
 
 def connect():
-    envPort = os.getenv('CHARIBEFS_PORT', '')
+    envPort = os.getenv('CHARYBDEFS_PORT', '')
     port = int(envPort) if envPort else 9090
     transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,7 +57,9 @@ def has_message(method, message):
 
 
 def connect():
-    transport = TSocket.TSocket('127.0.0.1', 9090)
+    envPort = os.getenv('CHARIBEFS_PORT', '')
+    port = int(envPort) if envPort else 9090
+    transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)
     protocol = TBinaryProtocol.TBinaryProtocol(transport)
     client = server.Client(protocol)

--- a/tests/python_client
+++ b/tests/python_client
@@ -12,7 +12,7 @@ from thrift.protocol import TBinaryProtocol
 
 try:
 
-    envPort = os.getenv('CHARIBEFS_PORT', '')
+    envPort = os.getenv('CHARYBDEFS_PORT', '')
     port = int(envPort) if envPort else 9090
     transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)

--- a/tests/python_client
+++ b/tests/python_client
@@ -12,7 +12,9 @@ from thrift.protocol import TBinaryProtocol
 
 try:
 
-    transport = TSocket.TSocket('127.0.0.1', 9090)
+    envPort = os.getenv('CHARIBEFS_PORT', '')
+    port = int(envPort) if envPort else 9090
+    transport = TSocket.TSocket('127.0.0.1', port)
     transport = TTransport.TBufferedTransport(transport)
     protocol = TBinaryProtocol.TBinaryProtocol(transport)
     client = server.Client(protocol)


### PR DESCRIPTION
This could be useful to have multiple mounts active simultaneously and in cases where the default port 9090 is unavailable.