### PR TITLE
Update recipes script to explicitly call python2

### DIFF
--- a/cookbook/recipes
+++ b/cookbook/recipes
@@ -4,4 +4,4 @@ if [ ! -d gen-py ]; then
     thrift -r --gen py ../server.thrift &> /dev/null
 fi
 
-python recipes.py $1
+python2 recipes.py $1


### PR DESCRIPTION
Currently, in Ubuntu 20.04.2, this script errors out as
`python` is explicitly not linked to either python2 or 3.
This change updates the recipes script to explicitly call python2.